### PR TITLE
Fix the bug that host:port will not work after -t option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
+wait-for-it.sh host:port [host:port ...] [-s] [-t timeout] [-- command args]
 -h HOST | --host=HOST       Host or IP under test
 -p PORT | --port=PORT       TCP port under test
                             Alternatively, you specify the host and port as host:port
@@ -15,6 +15,11 @@ wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
 ```
 
 ## Examples
+
+```bash
+# Multiple services
+./wait-for-it.sh db:5432 web:443 -t 60 -s -- echo "Hello world"
+```
 
 For example, let's test to see if we can access port 80 on www.google.com, and if it is available, echo the message `google is up`.
 

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -70,6 +70,7 @@ parse_arguments() {
           HOST[$index]=${hostport[0]}
           PORT[$index]=${hostport[1]}
           shift 1
+          let index+=1
           ;;
           --child)
           CHILD=1
@@ -105,7 +106,6 @@ parse_arguments() {
           usage
           ;;
       esac
-      let index+=1
   done
   if [[ ${#HOST[@]} -eq 0 || ${#PORT[@]} -eq 0 ]]; then
       echoerr "Error: you need to provide a host and port to test."


### PR DESCRIPTION
./wait-for-it.sh will not work if:
./wait-for-it.sh -t 10 -s db1:5432 db2:5432

Also update the README to add an exmaple for adding multiple services.